### PR TITLE
Add a new value in color lookup

### DIFF
--- a/lib/colorNamer.js
+++ b/lib/colorNamer.js
@@ -106,6 +106,12 @@ var color_lookup =
     "name" : "red"
   },
   {
+    "h" : 0,
+    "s" : 0.5,
+    "b" :0.5,
+    "name" : "dark maroon"
+  },
+  {
     "h" : 05,
     "s" : 1,
     "b" :1,


### PR DESCRIPTION
@lm-n Currently since hsv value of [0,0.5,0.5] does not have a lookup value, certain colors are showing up as Nan. Examples
RGB - 212, 35, 43 and 128,64,65. Adding this value takes care of these numbers
  